### PR TITLE
[BUGFIX] Fix mages not being removed from the recruited list after rerecruiting

### DIFF
--- a/src/components/molecules/MageList/index.tsx
+++ b/src/components/molecules/MageList/index.tsx
@@ -17,7 +17,7 @@ const MageList = ({ mages }: Props) => (
       {mages
         .filter((m): m is Mage => !!m)
         .map((mage, index) => (
-          <MageTile mage={mage} key={mage.name} playerNumber={index + 1} />
+          <MageTile mage={mage} key={mage.id} playerNumber={index + 1} />
         ))}
     </Grid>
   </MageGridWrapper>


### PR DESCRIPTION
rerecruiting

Issue: #455

Mages stayed in the recruited list after rerecruiting because they were
distinguished by name (which is a non unique feature any more). The key
has been adapted to be the id instead.