### PR TITLE
[FEATURE] Add mage titles to barracks cards

### DIFF
--- a/src/components/molecules/MageList/MageTile/Body.tsx
+++ b/src/components/molecules/MageList/MageTile/Body.tsx
@@ -4,6 +4,7 @@ import { Mage } from 'aer-types/types'
 
 import ExpansionName from './ExpansionName'
 import Name from './Name'
+import Title from './Title'
 
 type Props = {
   mage: Mage
@@ -16,6 +17,7 @@ const Body = ({ mage, expansionName }: Props) => (
     <Name variant="h6" component="h2">
       {mage.name}
     </Name>
+    <Title>{mage.mageTitle}</Title>
   </React.Fragment>
 )
 

--- a/src/components/molecules/MageList/MageTile/Title.tsx
+++ b/src/components/molecules/MageList/MageTile/Title.tsx
@@ -3,6 +3,7 @@ import Typography from '@material-ui/core/Typography'
 
 const Title = styled(Typography)`
   color: #fff;
+  height: 1em;
 `
 
 export default Title

--- a/src/components/molecules/MageList/MageTile/Title.tsx
+++ b/src/components/molecules/MageList/MageTile/Title.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components/macro'
+import Typography from '@material-ui/core/Typography'
+
+const Title = styled(Typography)`
+  color: #fff;
+`
+
+export default Title


### PR DESCRIPTION
If you sort the mages by name, the main way to distinguish mages with multiple versions is by their title. Previously this was only visible on the Show Details page, which required clicking in and out for each mage.