### PR TITLE
FEATURE: unique mage names in expedition

### DIFF
--- a/dataParser/theDepths.js
+++ b/dataParser/theDepths.js
@@ -75,7 +75,7 @@ const theDepthsData = {
     },
     {
       expansion: 'Depths',
-      name: 'Zhana',
+      name: "Z'hana",
       id: 'Zhana',
       mageTitle: 'Breach Mage Renegade',
       ability: `

--- a/dataParser/theVoid.js
+++ b/dataParser/theVoid.js
@@ -55,7 +55,7 @@ const theVoidData = {
     },
     {
       expansion: 'TV',
-      name: 'XaxosTV',
+      name: 'Xaxos',
       id: 'XaxosTV',
       mageTitle: 'Voidbringer',
       ability: `

--- a/dataParser/warEternal.js
+++ b/dataParser/warEternal.js
@@ -171,7 +171,7 @@ const warEternalData = {
     },
     {
       expansion: 'WE',
-      name: 'MistWE',
+      name: 'Mist',
       id: 'MistWE',
       mageTitle: 'Voidwalker',
       ability: `

--- a/src/Redux/Store/Expeditions/Expeditions/helpers/__test__/convertExpeditionFromConfig.test.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/helpers/__test__/convertExpeditionFromConfig.test.ts
@@ -76,6 +76,7 @@ describe('convertFromConfig()', () => {
     },
     variantIdConfig: 'DEFAULT',
     bigPocketVariantConfig: false,
+    uniqueMageNamesConfig: true,
     sequenceConfig: {
       firstBranchId: 'wLZW1WbKvj',
       branches: {
@@ -220,6 +221,7 @@ describe('convertFromConfig()', () => {
       upgradedBasicNemesisCards: [],
       banished: [],
       bigPocketVariant: false,
+      uniqueMageNames: true,
       sequence: {
         firstBranchId: 'wLZW1WbKvj',
         branches: {

--- a/src/Redux/Store/Expeditions/Expeditions/helpers/__test__/convertExpeditionToConfig.test.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/helpers/__test__/convertExpeditionToConfig.test.ts
@@ -90,6 +90,7 @@ describe('convertToConfig()', () => {
     upgradedBasicNemesisCards: [],
     banished: [],
     bigPocketVariant: false,
+    uniqueMageNames: true,
     sequence: {
       firstBranchId: 'wLZW1WbKvj',
       branches: {
@@ -169,16 +170,15 @@ describe('convertToConfig()', () => {
   it('should correctly convert expedition', () => {
     const result = convertExpeditionToConfig(expedition)
 
-    const {
-      usedExpansions,
-      ...settingsSnapshotConfig
-    } = expedition.settingsSnapshot
+    const { usedExpansions, ...settingsSnapshotConfig } =
+      expedition.settingsSnapshot
 
     const expected: types.ExpeditionConfig = {
       name: 'Test',
       seedConfig: 'TEST',
       settingsSnapshotConfig,
       bigPocketVariantConfig: false,
+      uniqueMageNamesConfig: true,
       sequenceConfig: {
         firstBranchId: 'wLZW1WbKvj',
         branches: {

--- a/src/Redux/Store/Expeditions/Expeditions/helpers/convertExpeditionFromConfig.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/helpers/convertExpeditionFromConfig.ts
@@ -11,6 +11,7 @@ export const convertExpeditionFromConfig = (
     id: expeditionId,
     name: config.name,
     bigPocketVariant: config.bigPocketVariantConfig,
+    uniqueMageNames: config.uniqueMageNamesConfig || false,
     score: 0,
     seed: {
       seed: config.seedConfig || shortid.generate(),

--- a/src/Redux/Store/Expeditions/Expeditions/helpers/convertExpeditionToConfig.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/helpers/convertExpeditionToConfig.ts
@@ -12,6 +12,7 @@ export const convertExpeditionToConfig = (
     name: expedition.name,
     seedConfig: expedition.seed.seed,
     bigPocketVariantConfig: expedition.bigPocketVariant,
+    uniqueMageNamesConfig: expedition.uniqueMageNames || false,
     initialBarracksConfig: expedition?.initialBarracksConfig,
     initialUBNCardsConfig: expedition?.initialUBNCardsConfig,
     settingsSnapshotConfig,

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/createExpeditionConfig/__test__/__snapshots__/createExpeditionConfig.test.ts.snap
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/createExpeditionConfig/__test__/__snapshots__/createExpeditionConfig.test.ts.snap
@@ -738,6 +738,7 @@ Object {
       "promos",
     ],
   },
+  "uniqueMageNames": false,
   "upgradedBasicNemesisCards": Array [],
 }
 `;

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/createExpeditionConfig/__test__/createExpeditionConfig.test.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/createExpeditionConfig/__test__/createExpeditionConfig.test.ts
@@ -25,6 +25,7 @@ describe('createExpeditionConfig()', () => {
       variantId: 'SHORT',
       name: 'Test expedition config',
       bigPocketVariant: true,
+      uniqueMageNames: false,
       marketId: 'market1',
       seedValue: 'TEST',
     })
@@ -39,6 +40,7 @@ describe('createExpeditionConfig()', () => {
       variantId: 'SHORT',
       name: 'Test expedition config',
       bigPocketVariant: true,
+      uniqueMageNames: false,
       marketId: 'market1',
       seedValue: 'TEST_SEED',
     })
@@ -62,6 +64,7 @@ describe('createExpeditionConfig()', () => {
       variantId: 'SHORT',
       name: 'Test expedition config',
       bigPocketVariant: true,
+      uniqueMageNames: false,
       marketId: 'market1',
     })
 

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/createExpeditionConfig/handleWithoutConfig.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/createExpeditionConfig/handleWithoutConfig.ts
@@ -13,11 +13,12 @@ import { getLatestMigrationVersion } from 'Redux/Store/Expeditions/Expeditions/m
 import {
   createArrayWithDefaultValues,
   createIdList,
+  createUniqueNameMageList,
   getRandomEntity,
 } from 'Redux/helpers'
 
 export const handleWithoutConfig = (
-  { variantId, name, bigPocketVariant, marketId, seedValue }: BaseConfig,
+  { variantId, name, bigPocketVariant, uniqueMageNames, marketId, seedValue }: BaseConfig,
   state: RootState
 ) => {
   /////////////////////////
@@ -37,14 +38,25 @@ export const handleWithoutConfig = (
   ///////////////////////////
 
   // Mages
-  const mageIdsResult = createIdList(
-    settingsSnapshot.availableMageIds,
-    createArrayWithDefaultValues(4, 'EMPTY'),
-    getRandomEntity,
-    seed
-  )
-
-  const mageIds = mageIdsResult.result
+  let mageIdsResult, mageIds
+  if (uniqueMageNames) {
+    const magesResult = createUniqueNameMageList(
+      selectors.Settings.Expansions.getSelectedMagesForSelectedExpansions(state),
+      createArrayWithDefaultValues(4, 'EMPTY'),
+      getRandomEntity,
+      seed
+    )
+    mageIds = magesResult.result.map((mage) => mage.id)
+    mageIdsResult = {result: mageIds, seed: magesResult.seed}
+  } else {
+    mageIdsResult = createIdList(
+      settingsSnapshot.availableMageIds,
+      createArrayWithDefaultValues(4, 'EMPTY'),
+      getRandomEntity,
+      seed
+    )
+    mageIds = mageIdsResult.result
+  }
 
   // Supply
   const availableCards = selectors.Settings.Expansions.Cards.getCardsByIdList(
@@ -115,6 +127,7 @@ export const handleWithoutConfig = (
     upgradedBasicNemesisCards: [],
     banished: [],
     bigPocketVariant: bigPocketVariant,
+    uniqueMageNames: uniqueMageNames || false,
     sequence: {
       firstBranchId: battles[0].id,
       branches: battles.reduce((acc, battle) => {

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollLossRewards/index.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollLossRewards/index.ts
@@ -121,7 +121,9 @@ const rollLossRewards = (
     expeditionId,
   })
 
-  const mageIds = selectors.getStillAvailableMageIds(state, { expeditionId })
+  const mageIds = expedition.uniqueMageNames
+    ? selectors.getStillAvailableMageWithUniqueNameIds(state, { expeditionId })
+    : selectors.getStillAvailableMageIds(state, { expeditionId })
 
   return handleRewardType({
     rewardType,

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/__test__/__fixtures__/expeditionState.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/__test__/__fixtures__/expeditionState.ts
@@ -4617,7 +4617,7 @@ export const state = {
             },
             Zhana: {
               expansion: 'Depths',
-              name: 'Zhana',
+              name: "Z'hana",
               id: 'Zhana',
               mageTitle: 'Breach Mage Renegade',
               ability:
@@ -5051,7 +5051,7 @@ export const state = {
             },
             XaxosTV: {
               expansion: 'TV',
-              name: 'XaxosTV',
+              name: 'Xaxos',
               id: 'XaxosTV',
               mageTitle: 'Voidbringer',
               ability:
@@ -5156,7 +5156,7 @@ export const state = {
             },
             MistWE: {
               expansion: 'WE',
-              name: 'MistWE',
+              name: 'Mist',
               id: 'MistWE',
               mageTitle: 'Voidwalker',
               ability:
@@ -5622,7 +5622,7 @@ export const state = {
             },
             Zhana: {
               expansion: 'Depths',
-              name: 'Zhana',
+              name: "Z'hana",
               id: 'Zhana',
               mageTitle: 'Zbuntowana Magini Bram',
               ability:
@@ -5727,7 +5727,7 @@ export const state = {
             },
             XaxosTV: {
               expansion: 'TV',
-              name: 'XaxosTV',
+              name: 'Xaxos',
               id: 'XaxosTV',
               mageTitle: 'Siewca Pustki',
               ability:
@@ -5832,7 +5832,7 @@ export const state = {
             },
             MistWE: {
               expansion: 'WE',
-              name: 'MistWE',
+              name: 'Mist',
               id: 'MistWE',
               mageTitle: 'Krocząca Przez Otchłań',
               ability:

--- a/src/Redux/Store/Expeditions/Expeditions/types.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/types.ts
@@ -46,6 +46,7 @@ export type BaseConfig = {
   variantId?: string
   name: string
   bigPocketVariant: boolean
+  uniqueMageNames?: boolean
   marketId: string
   expeditionConfig?: types.ImportedExpeditionConfig
   seedValue?: string

--- a/src/Redux/Store/selectors.ts
+++ b/src/Redux/Store/selectors.ts
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect'
 import * as Settings from './Settings'
 import * as Expeditions from './Expeditions'
 import { getContentByIdWithLanguageFallback } from './Settings/Expansions/helpers'
+import { magesHaveSameName } from 'Redux/helpers'
 
 export const getUpgradedBasicNemesisCardsByExpeditionId = createSelector(
   [
@@ -11,7 +12,7 @@ export const getUpgradedBasicNemesisCardsByExpeditionId = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (expedition, content, languages) =>
-    expedition.upgradedBasicNemesisCards.map(id =>
+    expedition.upgradedBasicNemesisCards.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
@@ -23,7 +24,7 @@ export const getExpeditionSupply = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (expedition, content, languages) =>
-    expedition.barracks.supplyIds.map(id =>
+    expedition.barracks.supplyIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
@@ -35,7 +36,7 @@ export const getExpeditionMages = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (expedition, content, languages) =>
-    expedition.barracks.mageIds.map(id =>
+    expedition.barracks.mageIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
@@ -47,7 +48,7 @@ export const getExpeditionTreasure = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (expedition, content, languages) =>
-    expedition.barracks.treasureIds.map(id =>
+    expedition.barracks.treasureIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
@@ -59,7 +60,7 @@ export const getExpeditionUpgradedBasicNemesis = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (expedition, content, languages) =>
-    expedition.upgradedBasicNemesisCards.map(id =>
+    expedition.upgradedBasicNemesisCards.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
@@ -71,7 +72,7 @@ export const getExpeditionBanishedCards = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (expedition, content, languages) =>
-    expedition.banished.map(id =>
+    expedition.banished.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
@@ -83,7 +84,7 @@ export const getAvailableNemesisForExpeditionId = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (settingsSnapshot, content, languages) =>
-    settingsSnapshot.availableNemesisIds.map(id =>
+    settingsSnapshot.availableNemesisIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
@@ -95,7 +96,7 @@ export const getAvailableCardsForExpeditionId = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (settingsSnapshot, content, languages) =>
-    settingsSnapshot.availableCardIds.map(id =>
+    settingsSnapshot.availableCardIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
@@ -107,7 +108,7 @@ export const getAvailableMagesForExpeditionId = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (settingsSnapshot, content, languages) =>
-    settingsSnapshot.availableMageIds.map(id =>
+    settingsSnapshot.availableMageIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
@@ -119,22 +120,24 @@ export const getAvailableTreasureForExpeditionId = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (settingsSnapshot, content, languages) =>
-    settingsSnapshot.availableTreasureIds.map(id =>
+    settingsSnapshot.availableTreasureIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, content, id)
     )
 )
 
-export const getAvailableUpgradedBasicNemesisCardsForExpeditionId = createSelector(
-  [
-    Expeditions.selectors.Expeditions.getSettingsSnapshotByExpeditionId,
-    Settings.selectors.Expansions.UpgradedBasicNemesisCards.content.getContent,
-    Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
-  ],
-  (settingsSnapshot, content, languages) =>
-    settingsSnapshot.availableUpgradedBasicNemesisCardIds.map(id =>
-      getContentByIdWithLanguageFallback(languages, content, id)
-    )
-)
+export const getAvailableUpgradedBasicNemesisCardsForExpeditionId =
+  createSelector(
+    [
+      Expeditions.selectors.Expeditions.getSettingsSnapshotByExpeditionId,
+      Settings.selectors.Expansions.UpgradedBasicNemesisCards.content
+        .getContent,
+      Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
+    ],
+    (settingsSnapshot, content, languages) =>
+      settingsSnapshot.availableUpgradedBasicNemesisCardIds.map((id) =>
+        getContentByIdWithLanguageFallback(languages, content, id)
+      )
+  )
 
 export const getStillAvailableGemIds = createSelector(
   [
@@ -144,9 +147,9 @@ export const getStillAvailableGemIds = createSelector(
   ],
   (availableCards, expeditionSupplyIds, banishedIds) =>
     availableCards
-      .filter(card => card.type === 'Gem')
-      .map(card => card.id)
-      .filter(id => ![...expeditionSupplyIds, ...banishedIds].includes(id))
+      .filter((card) => card.type === 'Gem')
+      .map((card) => card.id)
+      .filter((id) => ![...expeditionSupplyIds, ...banishedIds].includes(id))
 )
 
 export const getStillAvailableGems = createSelector(
@@ -156,7 +159,7 @@ export const getStillAvailableGems = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (cards, stillAvailableGemIds, languages) =>
-    stillAvailableGemIds.map(id =>
+    stillAvailableGemIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, cards, id)
     )
 )
@@ -169,9 +172,9 @@ export const getStillAvailableRelicIds = createSelector(
   ],
   (availableCards, expeditionSupplyIds, banishedIds) =>
     availableCards
-      .filter(card => card.type === 'Relic')
-      .map(card => card.id)
-      .filter(id => ![...expeditionSupplyIds, ...banishedIds].includes(id))
+      .filter((card) => card.type === 'Relic')
+      .map((card) => card.id)
+      .filter((id) => ![...expeditionSupplyIds, ...banishedIds].includes(id))
 )
 
 export const getStillAvailableRelics = createSelector(
@@ -181,7 +184,7 @@ export const getStillAvailableRelics = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (cards, stillAvailableRelicIds, languages) =>
-    stillAvailableRelicIds.map(id =>
+    stillAvailableRelicIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, cards, id)
     )
 )
@@ -194,9 +197,9 @@ export const getStillAvailableSpellIds = createSelector(
   ],
   (availableCards, expeditionSupplyIds, banishedIds) =>
     availableCards
-      .filter(card => card.type === 'Spell')
-      .map(card => card.id)
-      .filter(id => ![...expeditionSupplyIds, ...banishedIds].includes(id))
+      .filter((card) => card.type === 'Spell')
+      .map((card) => card.id)
+      .filter((id) => ![...expeditionSupplyIds, ...banishedIds].includes(id))
 )
 
 export const getStillAvailableSpells = createSelector(
@@ -206,7 +209,7 @@ export const getStillAvailableSpells = createSelector(
     Settings.selectors.Expansions.Languages.getLanguagesByExpansion,
   ],
   (cards, stillAvailableSpellIds, languages) =>
-    stillAvailableSpellIds.map(id =>
+    stillAvailableSpellIds.map((id) =>
       getContentByIdWithLanguageFallback(languages, cards, id)
     )
 )
@@ -218,8 +221,16 @@ export const getStillAvailableMageIds = createSelector(
   ],
   (availableMages, expeditionMageIds) =>
     availableMages
-      .map(mage => mage.id)
-      .filter(id => !expeditionMageIds.includes(id))
+      .map((mage) => mage.id)
+      .filter((id) => !expeditionMageIds.includes(id))
+)
+
+export const getStillAvailableMageWithUniqueNameIds = createSelector(
+  [getAvailableMagesForExpeditionId, getExpeditionMages],
+  (availableMages, expeditionMages) =>
+    availableMages
+      .filter((av) => !expeditionMages.some((em) => magesHaveSameName(av, em)))
+      .map((mage) => mage.id)
 )
 
 // Inversion of control -> this is so that we can compose a selector with
@@ -228,8 +239,8 @@ export const getStillAvailableMageIds = createSelector(
 // We will denote such a callback with a '$' prefix for the consuming parameter
 const getCallbackForAllTreasuresByLevelFromIdList = createSelector(
   [Settings.selectors.Expansions.Treasures.getTreasureIdsByTreasureLevel],
-  tByLevel => (treasureIds: string[]) => {
-    return treasureIds.filter(id => tByLevel.includes(id))
+  (tByLevel) => (treasureIds: string[]) => {
+    return treasureIds.filter((id) => tByLevel.includes(id))
   }
 )
 
@@ -241,8 +252,8 @@ export const getStillAvailableTreasureIdsByLevel = createSelector(
   ],
   (treasureIds, allAvailable, $getTreasuresByLevelFrom) => {
     const stillAvailable = allAvailable
-      .map(t => t.id)
-      .filter(t => !treasureIds.includes(t))
+      .map((t) => t.id)
+      .filter((t) => !treasureIds.includes(t))
 
     return $getTreasuresByLevelFrom(stillAvailable)
   }

--- a/src/__fixtures__/exampleExpeditionConfig.ts
+++ b/src/__fixtures__/exampleExpeditionConfig.ts
@@ -3,6 +3,7 @@ import * as types from 'aer-types/types'
 export const ExampleExpeditionConfigBattlesOnly: types.ExpeditionConfig = {
   name: 'Example Expedition Full',
   bigPocketVariantConfig: false,
+  uniqueMageNamesConfig: false,
   sequenceConfig: {
     firstBranchId: 'FirstBattle',
     branches: {
@@ -436,6 +437,7 @@ export const ExampleExpeditionConfigBattlesOnly: types.ExpeditionConfig = {
 export const ExampleExpeditionConfigFull: types.ExpeditionConfig = {
   name: 'Example Expedition Full',
   bigPocketVariantConfig: false,
+  uniqueMageNamesConfig: false,
   sequenceConfig: {
     firstBranchId: 'TheLanding',
     branches: {

--- a/src/__fixtures__/rootState.ts
+++ b/src/__fixtures__/rootState.ts
@@ -4616,7 +4616,7 @@ export const rootState: RootState = {
             },
             Zhana: {
               expansion: 'Depths',
-              name: 'Zhana',
+              name: "Z'hana",
               id: 'Zhana',
               mageTitle: 'Breach Mage Renegade',
               ability:
@@ -5050,7 +5050,7 @@ export const rootState: RootState = {
             },
             XaxosTV: {
               expansion: 'TV',
-              name: 'XaxosTV',
+              name: 'Xaxos',
               id: 'XaxosTV',
               mageTitle: 'Voidbringer',
               ability:
@@ -5155,7 +5155,7 @@ export const rootState: RootState = {
             },
             MistWE: {
               expansion: 'WE',
-              name: 'MistWE',
+              name: 'Mist',
               id: 'MistWE',
               mageTitle: 'Voidwalker',
               ability:
@@ -5621,7 +5621,7 @@ export const rootState: RootState = {
             },
             Zhana: {
               expansion: 'Depths',
-              name: 'Zhana',
+              name: "Z'hana",
               id: 'Zhana',
               mageTitle: 'Zbuntowana Magini Bram',
               ability:
@@ -5726,7 +5726,7 @@ export const rootState: RootState = {
             },
             XaxosTV: {
               expansion: 'TV',
-              name: 'XaxosTV',
+              name: 'Xaxos',
               id: 'XaxosTV',
               mageTitle: 'Siewca Pustki',
               ability:
@@ -5831,7 +5831,7 @@ export const rootState: RootState = {
             },
             MistWE: {
               expansion: 'WE',
-              name: 'MistWE',
+              name: 'Mist',
               id: 'MistWE',
               mageTitle: 'Krocząca Przez Otchłań',
               ability:

--- a/src/aer-data/src/DE/theVoid/mages.ts
+++ b/src/aer-data/src/DE/theVoid/mages.ts
@@ -33,7 +33,7 @@ export const mages: Mage[] = [
   },
   {
     expansion: 'TV',
-    name: 'Xaxos (DL)',
+    name: 'Xaxos',
     id: 'XaxosTV',
     mageTitle: 'Herold der Leere',
     ability: `

--- a/src/aer-data/src/DE/warEternal/mages.ts
+++ b/src/aer-data/src/DE/warEternal/mages.ts
@@ -120,7 +120,7 @@ export const mages: Mage[] = [
   },
   {
     expansion: 'WE',
-    name: 'Mist (FdE)',
+    name: 'Mist',
     id: 'MistWE',
     mageTitle: 'Leeren-Schreiter',
     ability: `

--- a/src/aer-data/src/ENG/returnToGravehold/mages.ts
+++ b/src/aer-data/src/ENG/returnToGravehold/mages.ts
@@ -5,6 +5,7 @@ export const mages: Mage[] = [
     expansion: 'RTG',
     name: 'Ohat And Ulgimor',
     id: 'OhatAndUlgimor',
+    aliases: ['Ulgimor'],
     mageTitle: '',
     ability: `
       <h2>Enrapture</h2>

--- a/src/aer-data/src/ENG/theDepths/mages.ts
+++ b/src/aer-data/src/ENG/theDepths/mages.ts
@@ -62,7 +62,7 @@ export const mages: Mage[] = [
   },
   {
     expansion: 'Depths',
-    name: 'Zhana',
+    name: "Z'hana",
     id: 'Zhana',
     mageTitle: 'Breach Mage Renegade',
     ability: `

--- a/src/aer-data/src/ENG/theVoid/mages.ts
+++ b/src/aer-data/src/ENG/theVoid/mages.ts
@@ -33,7 +33,7 @@ export const mages: Mage[] = [
   },
   {
     expansion: 'TV',
-    name: 'XaxosTV',
+    name: 'Xaxos',
     id: 'XaxosTV',
     mageTitle: 'Voidbringer',
     ability: `

--- a/src/aer-data/src/ENG/warEternal/mages.ts
+++ b/src/aer-data/src/ENG/warEternal/mages.ts
@@ -126,7 +126,7 @@ export const mages: Mage[] = [
   },
   {
     expansion: 'WE',
-    name: 'MistWE',
+    name: 'Mist',
     id: 'MistWE',
     mageTitle: 'Voidwalker',
     ability: `

--- a/src/aer-data/src/PL/theDepths/mages.ts
+++ b/src/aer-data/src/PL/theDepths/mages.ts
@@ -62,7 +62,7 @@ export const mages: Mage[] = [
   },
   {
     expansion: 'Depths',
-    name: 'Zhana',
+    name: "Z'hana",
     id: 'Zhana',
     mageTitle: 'Zbuntowana Magini Bram',
     ability: `

--- a/src/aer-data/src/PL/theVoid/mages.ts
+++ b/src/aer-data/src/PL/theVoid/mages.ts
@@ -32,7 +32,7 @@ export const mages: Mage[] = [
   },
   {
     expansion: 'TV',
-    name: 'XaxosTV',
+    name: 'Xaxos',
     id: 'XaxosTV',
     mageTitle: 'Siewca Pustki',
     ability: `

--- a/src/aer-data/src/PL/warEternal/mages.ts
+++ b/src/aer-data/src/PL/warEternal/mages.ts
@@ -121,7 +121,7 @@ export const mages: Mage[] = [
   },
   {
     expansion: 'WE',
-    name: 'MistWE',
+    name: 'Mist',
     id: 'MistWE',
     mageTitle: 'Krocząca Przez Otchłań',
     ability: `

--- a/src/aer-types/types/data.ts
+++ b/src/aer-types/types/data.ts
@@ -100,6 +100,7 @@ export type Nemesis = ICreature & {
 export type Mage = ICreature & {
   uniqueStarters: ICard[]
   mageTitle: string | 'Custom'
+  aliases?: string[]
   ability: string | 'Custom'
   complexityRating?: number // keep this optional
   numberOfCharges: number | 'Custom'

--- a/src/aer-types/types/expeditions.ts
+++ b/src/aer-types/types/expeditions.ts
@@ -263,6 +263,7 @@ export type BaseExpeditionConfig = {
   seedConfig?: string
   sequenceConfig: SequenceConfig
   bigPocketVariantConfig: boolean
+  uniqueMageNamesConfig: boolean
   initialBarracksConfig?: Partial<Barracks>
   initialUBNCardsConfig?: string[]
 }
@@ -322,6 +323,7 @@ export type BaseExpedition = {
   id: string
   name: string
   bigPocketVariant: boolean
+  uniqueMageNames?: boolean
   score: number
   seed: ExpeditionSeed
   sequence: Sequence

--- a/src/components/molecules/MageList/MageTile/NameLine.tsx
+++ b/src/components/molecules/MageList/MageTile/NameLine.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components/macro'
+
+const NameLine = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+export default NameLine

--- a/src/components/pages/Expeditions/CreationDialog/UniqueMageNamesSelect.tsx
+++ b/src/components/pages/Expeditions/CreationDialog/UniqueMageNamesSelect.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import Checkbox from '@material-ui/core/Checkbox'
+import FormControl from '../FormControl'
+import FormLabel from './FormLabel'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+
+type Props = {
+  uniqueMageNames: boolean
+  changeUniqueMageNames: (value: boolean) => any
+}
+
+const UniqueMageNamesSelect = ({
+  uniqueMageNames,
+  changeUniqueMageNames,
+}: Props) => {
+  return (
+    <FormControl component={'fieldset' as 'div'}>
+      <FormLabel>Mage Selection</FormLabel>
+      <FormControlLabel
+        control={
+          <Checkbox
+            id="uniqueMageNames"
+            checked={uniqueMageNames}
+            onChange={() => changeUniqueMageNames(!uniqueMageNames)}
+          />
+        }
+        label="Unique Mage Names"
+      />
+    </FormControl>
+  )
+}
+
+export default React.memo(UniqueMageNamesSelect)

--- a/src/components/pages/Expeditions/CreationDialog/index.tsx
+++ b/src/components/pages/Expeditions/CreationDialog/index.tsx
@@ -8,6 +8,7 @@ import ModalBodyWrapper from 'components/atoms/ModalBodyWrapper'
 import ModalFooterWrapper from 'components/atoms/ModalFooterWrapper'
 
 import BigPocketSelect from 'components/pages/Expeditions/CreationDialog/BigPocketSelect'
+import UniqueMageNamesSelect from 'components/pages/Expeditions/CreationDialog/UniqueMageNamesSelect'
 import ConfigImport from './ConfigImport'
 import CreateButton from 'components/pages/Expeditions/CreationDialog/CreateButton'
 import MarketSelect from './MarketSelect'
@@ -45,6 +46,9 @@ const CreationDialog = ({
   const [bigPocketVariant, changeBigPocketVariant] = useState(
     expeditionConfig?.bigPocketVariantConfig || false
   )
+  const [uniqueMageNames, changeUniqueMageNames] = useState(
+    expeditionConfig?.uniqueMageNamesConfig || false
+  )
   const [selectedMarketId, selectMarketId] = useState(
     expeditionConfig?.settingsSnapshotConfig?.supplySetup?.id || 'random'
   )
@@ -74,6 +78,7 @@ const CreationDialog = ({
       variantId: selectedVariant,
       name: expeditionName,
       bigPocketVariant,
+      uniqueMageNames,
       marketId: selectedMarketId,
       seedValue,
     })
@@ -85,6 +90,7 @@ const CreationDialog = ({
       changeExpeditionConfig(expeditionConfig)
       changeExpeditionName(expeditionConfig?.name)
       changeBigPocketVariant(expeditionConfig?.bigPocketVariantConfig || false)
+      changeUniqueMageNames(expeditionConfig?.uniqueMageNamesConfig || false)
       selectMarketId(
         expeditionConfig?.settingsSnapshotConfig?.supplySetup?.id || 'random'
       )
@@ -95,6 +101,8 @@ const CreationDialog = ({
       selectMarketId,
       changeExpeditionConfig,
       changeExpeditionName,
+      changeBigPocketVariant,
+      changeUniqueMageNames,
       selectVariant,
       changeSeedValue,
     ]
@@ -124,6 +132,11 @@ const CreationDialog = ({
         <BigPocketSelect
           bigPocketVariant={bigPocketVariant}
           changeBigPocketVariant={changeBigPocketVariant}
+        />
+
+        <UniqueMageNamesSelect
+          uniqueMageNames={uniqueMageNames}
+          changeUniqueMageNames={changeUniqueMageNames}
         />
 
         {selectedVariant && (

--- a/src/components/pages/Expeditions/ExpeditionTile/Body.tsx
+++ b/src/components/pages/Expeditions/ExpeditionTile/Body.tsx
@@ -48,6 +48,11 @@ const Body = ({ expedition, usedExpansions }: Props) => (
         data-test="info--big-pocket"
       />
       <InfoItem
+        label="Unique Mage Names"
+        info={expedition.uniqueMageNames ? 'Yes' : 'No'}
+        data-test="info--unique-mage-names"
+      />
+      <InfoItem
         label="Seed"
         info={expedition.seed.seed}
         data-test="info--seed"


### PR DESCRIPTION
Option on expedition creation to have all mages have unique names.
This required a few consistency changes in the mage names, e.g. consistent apostrophe in Z'hana, removing the suffixes from the second versions of Xaxos and Mist, and adding an optional `aliases` field so Ohat And Ulgimor counts as Ulgimor.
Fixes #460