### PR TITLE
[BUGFIX] Gate Witch PL expedition info

### DIFF
--- a/src/aer-data/src/PL/warEternal/nemeses.ts
+++ b/src/aer-data/src/PL/warEternal/nemeses.ts
@@ -11,7 +11,7 @@ export const nemeses: Nemesis[] = [
     additionalInfo: `
         <p>
           Gdy Megiera Bram przyspiesza przepływ czasu, 
-          traci trzy żetony Nemezis zamiast czterech.
+          traci pięć żetonów Nemezis zamiast czterech.
         </p>
       `,
   },


### PR DESCRIPTION
Expedition description said that Gate Witch should lose 3 (one less) Nemesis tokens instead of 5 (one more).