### PR TITLE
[FEATURE] introducing wave info to expansion

### DIFF
--- a/cypress/integration/Expeditions/creationAndRunThrough.spec.ts
+++ b/cypress/integration/Expeditions/creationAndRunThrough.spec.ts
@@ -125,6 +125,7 @@ describe('Expedition creation and run through', () => {
     cy.get('p').contains('Oblivium Resin').should('be.visible')
     cy.get('p').contains('Transmogrifier').should('be.visible')
     cy.get('p').contains('Breach Extractor').should('be.visible')
+    cy.get('p').contains('Amplify Vision').scrollIntoView()
     cy.get('p').contains('Amplify Vision').should('be.visible')
     cy.get('p').contains('Feral Lightning').should('be.visible')
     cy.get('p').contains('Celestial Spire').should('be.visible')

--- a/src/Redux/Store/Settings/Expansions/Expansions/content/selectors.ts
+++ b/src/Redux/Store/Settings/Expansions/Expansions/content/selectors.ts
@@ -1,10 +1,11 @@
 import { ExpansionContentStateSlice } from './types'
 import { createSelector } from 'reselect'
 import * as Languages from '../../Languages'
+import * as Ids from '../ids'
+import * as types from 'aer-types/types'
 
 import { selectors as LanguageSelectors } from '../../Languages'
 import { ContentStruct } from '../../helpers'
-import { Expansion } from 'aer-types/types'
 
 const getContent = (state: ExpansionContentStateSlice) =>
   state.Settings.Expansions.Expansions.content
@@ -13,7 +14,7 @@ const getId = (_: unknown, props: { expansionId: string }) => props.expansionId
 
 export const getContentWithLanguageFallback = (
   languages: Languages.State,
-  content: ContentStruct<Expansion>,
+  content: ContentStruct<types.Expansion>,
   id: string
 ) => {
   // Just get the corresponding expansion id from the english version
@@ -22,6 +23,18 @@ export const getContentWithLanguageFallback = (
   return content[language][id] || content.ENG[id]
 }
 
+const getExpansionsWithLanguageFallback = createSelector(
+  [getContent, Ids.selectors.getIds, LanguageSelectors.getLanguagesByExpansion],
+  (content, ids, languages) => {
+    let result: types.Expansions = {}
+    ids.forEach(
+      (id) =>
+        (result[id] = getContentWithLanguageFallback(languages, content, id))
+    )
+    return result
+  }
+)
+
 const getExpansionById = createSelector(
   [LanguageSelectors.getLanguagesByExpansion, getContent, getId],
   getContentWithLanguageFallback
@@ -29,5 +42,6 @@ const getExpansionById = createSelector(
 
 export const selectors = {
   getContent,
+  getExpansionsWithLanguageFallback,
   getExpansionById,
 }

--- a/src/aer-data/src/DE/aeonsEnd/index.ts
+++ b/src/aer-data/src/DE/aeonsEnd/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const aeonsEndData: IExpansion = {
   id: 'AE',
   name: 'Aeons End',
+  wave: 'W1-BA - Aeons End',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/DE/outerDark/index.ts
+++ b/src/aer-data/src/DE/outerDark/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const outerDarkData: IExpansion = {
   id: 'OD',
   name: 'Hinter der Finsternis',
+  wave: 'W2-E1 - Für die Ewigkeit',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/DE/promos/index.ts
+++ b/src/aer-data/src/DE/promos/index.ts
@@ -10,6 +10,7 @@ import { upgradedBasicNemesisCards } from './upgradedBasicNemesisCards'
 export const promosData: IExpansion = {
   id: 'promos',
   name: 'Promos',
+  wave: 'Weitere',
   type: 'promo',
   mages,
   nemeses,

--- a/src/aer-data/src/DE/theDepths/index.ts
+++ b/src/aer-data/src/DE/theDepths/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theDepthsData: IExpansion = {
   id: 'Depths',
   name: 'Aus den Tiefen',
+  wave: 'W1-E1 - Aeons End',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/DE/theNameless/index.ts
+++ b/src/aer-data/src/DE/theNameless/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theNamelessData: IExpansion = {
   id: 'Nameless',
   name: 'Das Namenlose',
+  wave: 'W1-E2 - Aeons End',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/DE/theVoid/index.ts
+++ b/src/aer-data/src/DE/theVoid/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theVoidData: IExpansion = {
   id: 'TV',
   name: 'Die Leere',
+  wave: 'W2-E2 - Für die Ewigkeit',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/DE/warEternal/index.ts
+++ b/src/aer-data/src/DE/warEternal/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const warEternalData: IExpansion = {
   id: 'WE',
   name: 'Für die Ewigkeit',
+  wave: 'W2-BA - Für die Ewigkeit',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/aeonsEnd/index.ts
+++ b/src/aer-data/src/ENG/aeonsEnd/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const aeonsEndData: IExpansion = {
   id: 'AE',
   name: 'Aeons End',
+  wave: 'W1 - Aeons End',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/buriedSecrets/index.ts
+++ b/src/aer-data/src/ENG/buriedSecrets/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const buriedSecretsData: IExpansion = {
   id: 'BS',
   name: 'Buried Secrets',
+  wave: 'W3 - Legacy',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/community/index.ts
+++ b/src/aer-data/src/ENG/community/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const communityData: IExpansion = {
   id: 'community',
   name: 'Community',
+  wave: 'Others',
   type: 'promo',
   mages,
   nemeses,

--- a/src/aer-data/src/ENG/intoTheWild/index.ts
+++ b/src/aer-data/src/ENG/intoTheWild/index.ts
@@ -8,6 +8,7 @@ import { treasures } from './treasures'
 export const intoTheWildData: IExpansion = {
   id: 'IW',
   name: 'Into The Wild',
+  wave: 'W4 - The New Age',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/legacy/index.ts
+++ b/src/aer-data/src/ENG/legacy/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const legacyData: IExpansion = {
   id: 'Legacy',
   name: 'Legacy',
+  wave: 'W3 - Legacy',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/legacyOfGravehold/index.ts
+++ b/src/aer-data/src/ENG/legacyOfGravehold/index.ts
@@ -9,6 +9,7 @@ import { upgradedBasicNemesisCards } from './upgradedBasicNemesisCards'
 export const legacyOfGraveholdData: IExpansion = {
   id: 'LOG',
   name: 'Legacy of Gravehold',
+  wave: 'W6 - The Legacy of Gravehold',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/outcasts/index.ts
+++ b/src/aer-data/src/ENG/outcasts/index.ts
@@ -10,6 +10,7 @@ import { upgradedBasicNemesisCards } from './upgradedBasicNemesisCards'
 export const outcastsData: IExpansion = {
   id: 'O',
   name: 'Outcasts',
+  wave: 'W5 - Outcasts',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/outerDark/index.ts
+++ b/src/aer-data/src/ENG/outerDark/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const outerDarkData: IExpansion = {
   id: 'OD',
   name: 'Outer Dark',
+  wave: 'W2 - War Eternal',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/promos/index.ts
+++ b/src/aer-data/src/ENG/promos/index.ts
@@ -10,6 +10,7 @@ import { upgradedBasicNemesisCards } from './upgradedBasicNemesisCards'
 export const promosData: IExpansion = {
   id: 'promos',
   name: 'Promos',
+  wave: 'Others',
   type: 'promo',
   mages,
   nemeses,

--- a/src/aer-data/src/ENG/returnToGravehold/index.ts
+++ b/src/aer-data/src/ENG/returnToGravehold/index.ts
@@ -8,6 +8,7 @@ import { treasures } from './treasures'
 export const returnToGraveholdData: IExpansion = {
   id: 'RTG',
   name: 'Return To Gravehold',
+  wave: 'W5 - Outcasts',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/shatteredDreams/index.ts
+++ b/src/aer-data/src/ENG/shatteredDreams/index.ts
@@ -8,6 +8,7 @@ import { treasures } from './treasures'
 export const shatteredDreamsData: IExpansion = {
   id: 'SD',
   name: 'Shattered Dreams',
+  wave: 'W4 - The New Age',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/southernVillage/index.ts
+++ b/src/aer-data/src/ENG/southernVillage/index.ts
@@ -8,6 +8,7 @@ import { treasures } from './treasures'
 export const southernVillageData: IExpansion = {
   id: 'SV',
   name: 'Southern Village',
+  wave: 'W5 - Outcasts',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/theAncients/index.ts
+++ b/src/aer-data/src/ENG/theAncients/index.ts
@@ -9,6 +9,7 @@ import { upgradedBasicNemesisCards } from './upgradedBasicNemesisCards'
 export const theAncientsData: IExpansion = {
   id: 'TA',
   name: 'The Ancients',
+  wave: 'W4 - The New Age',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/theDepths/index.ts
+++ b/src/aer-data/src/ENG/theDepths/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theDepthsData: IExpansion = {
   id: 'Depths',
   name: 'The Depths',
+  wave: 'W1 - Aeons End',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/theNameless/index.ts
+++ b/src/aer-data/src/ENG/theNameless/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theNamelessData: IExpansion = {
   id: 'Nameless',
   name: 'The Nameless',
+  wave: 'W1 - Aeons End',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/theNewAge/index.ts
+++ b/src/aer-data/src/ENG/theNewAge/index.ts
@@ -10,6 +10,7 @@ import { upgradedBasicNemesisCards } from './upgradedBasicNemesisCards'
 export const newAgeData: IExpansion = {
   id: 'NA',
   name: 'The New Age',
+  wave: 'W4 - The New Age',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/theRuins/index.ts
+++ b/src/aer-data/src/ENG/theRuins/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theRuinsData: IExpansion = {
   id: 'RU',
   name: 'The Ruins',
+  wave: 'W6 - The Legacy of Gravehold',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/theVoid/index.ts
+++ b/src/aer-data/src/ENG/theVoid/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theVoidData: IExpansion = {
   id: 'TV',
   name: 'The Void',
+  wave: 'W2 - War Eternal',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/ENG/warEternal/index.ts
+++ b/src/aer-data/src/ENG/warEternal/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const warEternalData: IExpansion = {
   id: 'WE',
   name: 'War Eternal',
+  wave: 'W2 - War Eternal',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/FR/aeonsEnd/index.ts
+++ b/src/aer-data/src/FR/aeonsEnd/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const aeData: IExpansion = {
   id: 'AE',
   name: "Aeon's End",
+  wave: "W1 - Aeon's End",
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/FR/theDepths/index.ts
+++ b/src/aer-data/src/FR/theDepths/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const depthsData: IExpansion = {
   id: 'Depths',
   name: 'Les Profondeurs',
+  wave: "W1 - Aeon's End",
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/FR/theNameless/index.ts
+++ b/src/aer-data/src/FR/theNameless/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const namelessData: IExpansion = {
   id: 'Nameless',
   name: 'Les Sans-Noms',
+  wave: "W1 - Aeon's End",
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/FR/warEternal/index.ts
+++ b/src/aer-data/src/FR/warEternal/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const weData: IExpansion = {
   id: 'WE',
   name: 'Guerre éternelle',
+  wave: 'W2 - Guerre éternelle',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/aeonsEnd/index.ts
+++ b/src/aer-data/src/PL/aeonsEnd/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const aeonsEndData: IExpansion = {
   id: 'AE',
   name: 'Aeons End',
+  wave: 'W1 - Aeons End',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/buriedSecrets/index.ts
+++ b/src/aer-data/src/PL/buriedSecrets/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const buriedSecretsData: IExpansion = {
   id: 'BS',
   name: 'Pogrzebane Sekrety',
+  wave: 'W3 - Legacy',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/intoTheWild/index.ts
+++ b/src/aer-data/src/PL/intoTheWild/index.ts
@@ -8,6 +8,7 @@ import { treasures } from './treasures'
 export const intoTheWildData: IExpansion = {
   id: 'IW',
   name: 'Tajemnica Dziczy',
+  wave: 'W4 - Nowy Początek',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/legacy/index.ts
+++ b/src/aer-data/src/PL/legacy/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const legacyData: IExpansion = {
   id: 'Legacy',
   name: 'Legacy',
+  wave: 'W3 - Legacy',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/outerDark/index.ts
+++ b/src/aer-data/src/PL/outerDark/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const outerDarkData: IExpansion = {
   id: 'OD',
   name: 'Niezbadany Mrok',
+  wave: 'W2 - Wieczna Wojna',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/promos/index.ts
+++ b/src/aer-data/src/PL/promos/index.ts
@@ -9,6 +9,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const promosData: IExpansion = {
   id: 'promos',
   name: 'Promos',
+  wave: 'Dalej',
   type: 'promo',
   mages,
   nemeses,

--- a/src/aer-data/src/PL/theDepths/index.ts
+++ b/src/aer-data/src/PL/theDepths/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theDepthsData: IExpansion = {
   id: 'Depths',
   name: 'Czeluście',
+  wave: 'W1 - Aeons End',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/theNameless/index.ts
+++ b/src/aer-data/src/PL/theNameless/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theNamelessData: IExpansion = {
   id: 'Nameless',
   name: 'Bezimienni',
+  wave: 'W1 - Aeons End',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/theNewAge/index.ts
+++ b/src/aer-data/src/PL/theNewAge/index.ts
@@ -10,6 +10,7 @@ import { upgradedBasicNemesisCards } from './upgradedBasicNemesisCards'
 export const newAgeData: IExpansion = {
   id: 'NA',
   name: 'Nowy Początek',
+  wave: 'W4 - Nowy Początek',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/theVoid/index.ts
+++ b/src/aer-data/src/PL/theVoid/index.ts
@@ -7,6 +7,7 @@ import { cards } from './cards'
 export const theVoidData: IExpansion = {
   id: 'TV',
   name: 'Otchłań',
+  wave: 'W2 - Wieczna Wojna',
   type: 'mini',
   nemeses,
   mages,

--- a/src/aer-data/src/PL/warEternal/index.ts
+++ b/src/aer-data/src/PL/warEternal/index.ts
@@ -8,6 +8,7 @@ import { basicNemesisCards } from './basicNemesisCards'
 export const warEternalData: IExpansion = {
   id: 'WE',
   name: 'Wieczna Wojna',
+  wave: 'W2 - Wieczna Wojna',
   type: 'standalone',
   nemeses,
   mages,

--- a/src/aer-data/src/createNormalizedData.ts
+++ b/src/aer-data/src/createNormalizedData.ts
@@ -41,6 +41,7 @@ export const createNormalizedData = (
           [id]: {
             id,
             name: expansion.name,
+            wave: expansion.wave,
             type: expansion.type,
           },
         },

--- a/src/aer-types/types/data.ts
+++ b/src/aer-types/types/data.ts
@@ -65,6 +65,7 @@ export type UpgradedBasicNemesisCard = BasicNemesisCard & {
 export interface IExpansion {
   id: string
   name: string
+  wave: string
   type: ExpansionType
   nemeses: Array<Nemesis>
   mages: Array<Mage>
@@ -81,6 +82,7 @@ export interface IExpansionData {
 export type Expansion = {
   id: string
   name: string
+  wave: string
   type: ExpansionType
 }
 

--- a/src/components/molecules/MarketTile/Body.tsx
+++ b/src/components/molecules/MarketTile/Body.tsx
@@ -21,10 +21,10 @@ type Props = {
     threshold?: number
     values?: Array<number>
   }
-  expansionName: string
+  expansion: types.Expansion | null
 }
 
-const Body = ({ supplyCard, expansionName }: Props) => {
+const Body = ({ supplyCard, expansion }: Props) => {
   const { type, operation, values, threshold } = supplyCard
 
   return (
@@ -38,9 +38,10 @@ const Body = ({ supplyCard, expansionName }: Props) => {
         {supplyCard && supplyCard.name ? supplyCard.name : '-'}
       </Name>
       <List>
+        <InfoItem label="Set" info={expansion ? expansion.name : '-'} />
         <InfoItem
-          label="Set"
-          info={expansionName !== '' ? expansionName : '-'}
+          label="Wave"
+          info={expansion && expansion.wave ? expansion.wave : '-'}
         />
         <InfoItem
           label="Cost"

--- a/src/components/molecules/MarketTile/index.tsx
+++ b/src/components/molecules/MarketTile/index.tsx
@@ -76,7 +76,9 @@ const getCard = (marketTile: MaybeMarketTile): MaybeOutputMarketTile => {
 
 const mapStateToProps = (state: RootState) => ({
   expansions:
-    selectors.Settings.Expansions.Expansions.content.getContent(state),
+    selectors.Settings.Expansions.Expansions.content.getExpansionsWithLanguageFallback(
+      state
+    ),
 })
 
 const mapDispatchToProps = {}
@@ -160,10 +162,8 @@ const MarketTile = ({
             body={
               <Body
                 supplyCard={marketTile}
-                expansionName={
-                  marketTile.expansion
-                    ? expansions.ENG[marketTile.expansion].name
-                    : ''
+                expansion={
+                  marketTile.expansion ? expansions[marketTile.expansion] : null
                 }
               />
             }

--- a/src/components/molecules/SupplyCardInformation/index.tsx
+++ b/src/components/molecules/SupplyCardInformation/index.tsx
@@ -21,13 +21,14 @@ type Props = {
     keywords: string[]
     effect: string
   }
-  expansionName: string
+  expansion: types.Expansion
   theme: any
 }
 
-const Body = ({ card, expansionName, theme }: Props) => (
+const Body = ({ card, expansion, theme }: Props) => (
   <React.Fragment>
-    <InfoItem label="Expansion" info={expansionName} />
+    <InfoItem label="Expansion" info={expansion.name} />
+    <InfoItem label="Wave" info={expansion.wave || '-'} />
     <InfoItem label="Type" info={card.type} />
     <InfoItem label="Cost" info={card.cost.toString()} />
 

--- a/src/components/molecules/SupplyModal/index.tsx
+++ b/src/components/molecules/SupplyModal/index.tsx
@@ -23,9 +23,10 @@ export type CardProperties = {
 }
 
 const mapStateToProps = (state: RootState, _: any) => ({
-  expansions: selectors.Settings.Expansions.Expansions.content.getContent(
-    state
-  ),
+  expansions:
+    selectors.Settings.Expansions.Expansions.content.getExpansionsWithLanguageFallback(
+      state
+    ),
 })
 
 type Props = ReturnType<typeof mapStateToProps> & {
@@ -40,10 +41,7 @@ const SupplyModal = ({ card, expansions, theme, RenderModal }: Props) => {
     : theme.colors.text
   const titleLabel = card ? card.name : ''
   const body = card ? (
-    <Body
-      card={card}
-      expansionName={expansions.ENG[card.expansion].name || ''}
-    />
+    <Body card={card} expansion={expansions[card.expansion]} />
   ) : (
     'No content'
   )

--- a/src/components/pages/Settings/Expansions/ActiveSets/ExpansionList/Checkbox.tsx
+++ b/src/components/pages/Settings/Expansions/ActiveSets/ExpansionList/Checkbox.tsx
@@ -41,7 +41,7 @@ const Checkbox = ({ expansion, changeHandler, selected }: Props) => {
       <CheckboxWithControls
         id={expansion.id}
         checked={selected}
-        label={expansion.name}
+        label={formatExpansionName(expansion)}
         changeHandler={handleChange}
       />
     </React.Fragment>
@@ -52,3 +52,9 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(React.memo(Checkbox))
+
+function formatExpansionName(expansion: types.Expansion): string {
+  return expansion.wave
+    ? expansion.name + ' (' + expansion.wave + ')'
+    : expansion.name + ' (-)'
+}


### PR DESCRIPTION
Issue: #467

Phase 1:
 - Add wave attribute to Expansion/IExpansion data/type
 - Display wave in Settings -> Expansions
 - Display expansion/wave language dependent in Randomizer -> Supply
 - Display expansion/wave language dependent in card details