### PR TITLE
[FEATURE] Allow adding Friend and Foe cards to turn order

### DIFF
--- a/src/Redux/Store/TurnOrder/Configuration/__test__/helpers.test.ts
+++ b/src/Redux/Store/TurnOrder/Configuration/__test__/helpers.test.ts
@@ -14,6 +14,8 @@ import {
 
 const mockConfiguration: State = {
   Mode: 'Blitz',
+  Friend: false,
+  Foe: false,
   SelectedPlayerCount: AERData.turnordersetups['fourPlayers'],
   SelectedSetup: AERData.turnordersetups['fourPlayers'].variations['default'],
 }
@@ -38,6 +40,46 @@ describe('adjustSetup()', () => {
   const defaultVariation =
     AERData.turnordersetups.twoPlayers.variations['default']
 
+    it('should add friend card', () => {
+      const expected = {
+        id: 'default',
+        name: 'Default',
+        turnOrderCards: [
+          AERData.turnordercards['player1-1'],
+          AERData.turnordercards['player1-2'],
+          AERData.turnordercards['player2-1'],
+          AERData.turnordercards['player2-2'],
+          AERData.turnordercards['nemesis-1'],
+          AERData.turnordercards['nemesis-2'],
+          AERData.turnordercards['friend'],
+        ],
+      }
+  
+      const result = adjustSetup('Default', true, false, defaultVariation)
+  
+      expect(result).toEqual(expected)
+    })
+
+    it('should add foe card', () => {
+      const expected = {
+        id: 'default',
+        name: 'Default',
+        turnOrderCards: [
+          AERData.turnordercards['player1-1'],
+          AERData.turnordercards['player1-2'],
+          AERData.turnordercards['player2-1'],
+          AERData.turnordercards['player2-2'],
+          AERData.turnordercards['nemesis-1'],
+          AERData.turnordercards['nemesis-2'],
+          AERData.turnordercards['foe'],
+        ],
+      }
+  
+      const result = adjustSetup('Default', false, true, defaultVariation)
+  
+      expect(result).toEqual(expected)
+    })
+
   it('should return the default variation of tocs for 2 players', () => {
     const expected = {
       id: 'default',
@@ -52,7 +94,7 @@ describe('adjustSetup()', () => {
       ],
     }
 
-    const result = adjustSetup('Default', defaultVariation)
+    const result = adjustSetup('Default', false, false, defaultVariation)
 
     expect(result).toEqual(expected)
   })
@@ -71,7 +113,7 @@ describe('adjustSetup()', () => {
       ],
     }
 
-    const result = adjustSetup('Maelstrom', defaultVariation)
+    const result = adjustSetup('Maelstrom', false, false, defaultVariation)
 
     expect(result).toEqual(expected)
   })
@@ -90,7 +132,7 @@ describe('adjustSetup()', () => {
       ],
     }
 
-    const result = adjustSetup('Blitz', defaultVariation)
+    const result = adjustSetup('Blitz', false, false, defaultVariation)
 
     expect(result).toEqual(expected)
   })
@@ -109,7 +151,7 @@ describe('adjustSetup()', () => {
       ],
     }
 
-    const result = adjustSetup('Blitz + Maelstrom', defaultVariation)
+    const result = adjustSetup('Blitz + Maelstrom', false, false, defaultVariation)
 
     expect(result).toEqual(expected)
   })
@@ -128,7 +170,7 @@ describe('adjustSetup()', () => {
       ],
     }
 
-    const result = adjustSetup('Thief Of Dreams', defaultVariation)
+    const result = adjustSetup('Thief Of Dreams', false, false, defaultVariation)
 
     expect(result).toEqual(expected)
   })
@@ -147,7 +189,7 @@ describe('adjustSetup()', () => {
       ],
     }
 
-    const result = adjustSetup('Paradox of Myth and Bone', defaultVariation)
+    const result = adjustSetup('Paradox of Myth and Bone', false, false, defaultVariation)
 
     expect(result).toEqual(expected)
   })

--- a/src/Redux/Store/TurnOrder/Configuration/__test__/reducer.test.ts
+++ b/src/Redux/Store/TurnOrder/Configuration/__test__/reducer.test.ts
@@ -14,6 +14,8 @@ import {
 
 const mockConfiguration: State = {
   Mode: 'Blitz',
+  Friend: false,
+  Foe: false,
   SelectedPlayerCount: AERData.turnordersetups['fourPlayers'],
   SelectedSetup: AERData.turnordersetups['fourPlayers'].variations['default'],
 }
@@ -31,6 +33,8 @@ describe('TurnOrder | Configuration | reducer', () => {
   it('should handle SET_MODE', () => {
     const expected = {
       Mode: 'Maelstrom',
+      Friend: false,
+      Foe: false,
       SelectedPlayerCount: AERData.turnordersetups['fourPlayers'],
       SelectedSetup:
         AERData.turnordersetups['fourPlayers'].variations['default'],
@@ -41,9 +45,41 @@ describe('TurnOrder | Configuration | reducer', () => {
     expect(getModel(result)).toEqual(expected)
   })
 
+  it('should handle SET_FRIEND', () => {
+    const expected = {
+      Mode: 'Blitz',
+      Friend: true,
+      Foe: false,
+      SelectedPlayerCount: AERData.turnordersetups['fourPlayers'],
+      SelectedSetup:
+        AERData.turnordersetups['fourPlayers'].variations['default'],
+    }
+
+    const result = Reducer(mockConfiguration, actions.setFriend(true))
+
+    expect(getModel(result)).toEqual(expected)
+  })
+
+  it('should handle SET_FOE', () => {
+    const expected = {
+      Mode: 'Blitz',
+      Friend: false,
+      Foe: true,
+      SelectedPlayerCount: AERData.turnordersetups['fourPlayers'],
+      SelectedSetup:
+        AERData.turnordersetups['fourPlayers'].variations['default'],
+    }
+
+    const result = Reducer(mockConfiguration, actions.setFoe(true))
+
+    expect(getModel(result)).toEqual(expected)
+  })
+
   it('should handle SELECT_PLAYER_COUNT', () => {
     const expected = {
       Mode: 'Blitz',
+      Friend: false,
+      Foe: false,
       SelectedPlayerCount: AERData.turnordersetups['twoPlayers'],
       SelectedSetup:
         AERData.turnordersetups['twoPlayers'].variations['default'],
@@ -60,6 +96,8 @@ describe('TurnOrder | Configuration | reducer', () => {
   it('should handle SELECT_PLAYER_COUNT when player count is undefined', () => {
     const expected = {
       Mode: 'Blitz',
+      Friend: false,
+      Foe: false,
       SelectedPlayerCount: AERData.turnordersetups['fourPlayers'],
       SelectedSetup:
         AERData.turnordersetups['fourPlayers'].variations['default'],
@@ -77,6 +115,8 @@ describe('TurnOrder | Configuration | reducer', () => {
   it('should handle SELECT_SETUP', () => {
     const expected = {
       Mode: 'Blitz',
+      Friend: false,
+      Foe: false,
       SelectedPlayerCount: AERData.turnordersetups['fourPlayers'],
       SelectedSetup:
         AERData.turnordersetups['fourPlayers'].variations['splitPlayers'],
@@ -93,6 +133,8 @@ describe('TurnOrder | Configuration | reducer', () => {
   it('should handle SELECT_SETUP when setup does not exist for player count', () => {
     const expected = {
       Mode: 'Blitz',
+      Friend: false,
+      Foe: false,
       SelectedPlayerCount: AERData.turnordersetups['fourPlayers'],
       SelectedSetup:
         AERData.turnordersetups['fourPlayers'].variations['default'],

--- a/src/Redux/Store/TurnOrder/Configuration/__test__/selectors.test.ts
+++ b/src/Redux/Store/TurnOrder/Configuration/__test__/selectors.test.ts
@@ -2,6 +2,8 @@ import AERData from 'aer-data/src/index'
 
 import {
   ModeStateSlice,
+  FriendStateSlice,
+  FoeStateSlice,
   SelectedPlayerCountStateSlice,
   SelectedSetupStateSlice,
 } from '../types'
@@ -9,11 +11,15 @@ import {
 import { selectors } from 'Redux/Store/TurnOrder/Configuration/selectors'
 
 const mockConfiguration: ModeStateSlice &
+  FriendStateSlice &
+  FoeStateSlice &
   SelectedPlayerCountStateSlice &
   SelectedSetupStateSlice = {
   TurnOrder: {
     Configuration: {
       Mode: 'Blitz',
+      Friend: false,
+      Foe: false,
       SelectedPlayerCount: AERData.turnordersetups['fourPlayers'],
       SelectedSetup:
         AERData.turnordersetups['fourPlayers'].variations['default'],
@@ -99,6 +105,46 @@ describe('TurnOrder | Configuration | selectors', () => {
     }
 
     const result = selectors.getConfiguration(mockConfiguration)
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should add friend card with getConfiguration()', () => {
+    const expected = {
+      id: 'default',
+      name: 'Default',
+      turnOrderCards: [
+        AERData.turnordercards['player1-1'],
+        AERData.turnordercards['player2-1'],
+        AERData.turnordercards['player3-1'],
+        AERData.turnordercards['player4-1'],
+        AERData.turnordercards['blitz'],
+        AERData.turnordercards['nemesis-2'],
+        AERData.turnordercards['friend'],
+      ],
+    }
+
+    const result = selectors.getConfiguration({TurnOrder: {Configuration: {...mockConfiguration.TurnOrder.Configuration, Friend: true}}})
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should add foe card with getConfiguration()', () => {
+    const expected = {
+      id: 'default',
+      name: 'Default',
+      turnOrderCards: [
+        AERData.turnordercards['player1-1'],
+        AERData.turnordercards['player2-1'],
+        AERData.turnordercards['player3-1'],
+        AERData.turnordercards['player4-1'],
+        AERData.turnordercards['blitz'],
+        AERData.turnordercards['nemesis-2'],
+        AERData.turnordercards['foe'],
+      ],
+    }
+
+    const result = selectors.getConfiguration({TurnOrder: {Configuration: {...mockConfiguration.TurnOrder.Configuration, Foe: true}}})
 
     expect(result).toEqual(expected)
   })

--- a/src/Redux/Store/TurnOrder/Configuration/actions.ts
+++ b/src/Redux/Store/TurnOrder/Configuration/actions.ts
@@ -7,6 +7,8 @@ import { ActionTypes } from './types'
 export const actions = {
   noOp: () => createAction('@@REDUX_LOOP/ENFORCE_DEFAULT_HANDLING'),
   setMode: (mode: types.Mode) => createAction(ActionTypes.SET_MODE, mode),
+  setFriend: (friend: boolean) => createAction(ActionTypes.SET_FRIEND, friend),
+  setFoe: (foe: boolean) => createAction(ActionTypes.SET_FOE, foe),
   selectPlayerCount: (playerCountId: types.PlayerCountId) =>
     createAction(ActionTypes.SELECT_PLAYER_COUNT, playerCountId),
   selectSetup: (setupId: types.TurnorderSetupVariationId) =>

--- a/src/Redux/Store/TurnOrder/Configuration/helpers.ts
+++ b/src/Redux/Store/TurnOrder/Configuration/helpers.ts
@@ -19,10 +19,7 @@ const newStateWithDBWrite = (newState: State) => {
   )
 }
 
-const adjustSetup = (
-  mode: types.Mode,
-  setup: types.ITurnOrderSetup
-): types.ITurnOrderSetup => {
+const baseSetup = (mode: types.Mode, setup: types.ITurnOrderSetup): types.ITurnOrderSetup => {
   switch (mode) {
     case 'Maelstrom': {
       return {
@@ -98,9 +95,25 @@ const adjustSetup = (
 
     case 'Default':
     default: {
-      return setup
+      return {...setup}
     }
   }
+}
+
+const adjustSetup = (
+  mode: types.Mode,
+  friend: boolean,
+  foe: boolean,
+  setup: types.ITurnOrderSetup
+): types.ITurnOrderSetup => {
+  const rawSetup = baseSetup(mode, setup);
+  if (friend) {
+    rawSetup.turnOrderCards = [...rawSetup.turnOrderCards, AERData.turnordercards['friend']]
+  }
+  if (foe) {
+    rawSetup.turnOrderCards = [...rawSetup.turnOrderCards, AERData.turnordercards['foe']]
+  }
+  return rawSetup
 }
 
 export { newStateWithDBWrite, adjustSetup }

--- a/src/Redux/Store/TurnOrder/Configuration/reducer.ts
+++ b/src/Redux/Store/TurnOrder/Configuration/reducer.ts
@@ -9,6 +9,8 @@ import * as reducerHelpers from './reducerHelpers'
 
 export const initialState: State = {
   Mode: INITIAL_MODE,
+  Friend: false,
+  Foe: false,
   SelectedPlayerCount: INITIAL_PLAYER_SETUP,
   SelectedSetup: INITIAL_VARIATION,
 }
@@ -17,6 +19,14 @@ export const Reducer = (state: State = initialState, action: Action) => {
   switch (action.type) {
     case ActionTypes.SET_MODE: {
       return reducerHelpers.setMode(state, action)
+    }
+
+    case ActionTypes.SET_FRIEND: {
+      return reducerHelpers.setFriend(state, action)
+    }
+
+    case ActionTypes.SET_FOE: {
+      return reducerHelpers.setFoe(state, action)
     }
 
     case ActionTypes.SELECT_PLAYER_COUNT: {

--- a/src/Redux/Store/TurnOrder/Configuration/reducerHelpers/setMode.ts
+++ b/src/Redux/Store/TurnOrder/Configuration/reducerHelpers/setMode.ts
@@ -9,3 +9,19 @@ export const setMode = (
   const newState = { ...state, Mode: action.payload }
   return newStateWithDBWrite(newState)
 }
+
+export const setFriend = (
+  state: State,
+  action: ReturnType<typeof actions.setFriend>
+) => {
+  const newState = { ...state, Friend: action.payload }
+  return newStateWithDBWrite(newState)
+}
+
+export const setFoe = (
+  state: State,
+  action: ReturnType<typeof actions.setFoe>
+) => {
+  const newState = { ...state, Foe: action.payload }
+  return newStateWithDBWrite(newState)
+}

--- a/src/Redux/Store/TurnOrder/Configuration/selectors.ts
+++ b/src/Redux/Store/TurnOrder/Configuration/selectors.ts
@@ -2,6 +2,8 @@ import { createSelector } from 'reselect'
 
 import {
   ModeStateSlice,
+  FriendStateSlice,
+  FoeStateSlice,
   SelectedPlayerCountStateSlice,
   SelectedSetupStateSlice,
 } from './types'
@@ -10,6 +12,10 @@ import { adjustSetup } from './helpers'
 
 const getMode = (state: ModeStateSlice) => state.TurnOrder.Configuration.Mode
 
+const getFriend = (state: FriendStateSlice) => state.TurnOrder.Configuration.Friend
+
+const getFoe = (state: FoeStateSlice) => state.TurnOrder.Configuration.Foe
+
 const getSelectedPlayerCount = (state: SelectedPlayerCountStateSlice) =>
   state.TurnOrder.Configuration.SelectedPlayerCount
 
@@ -17,8 +23,8 @@ const getSelectedSetup = (state: SelectedSetupStateSlice) =>
   state.TurnOrder.Configuration.SelectedSetup
 
 const getConfiguration = createSelector(
-  [getMode, getSelectedSetup],
-  (mode, selectedSetup) => adjustSetup(mode, selectedSetup)
+  [getMode, getFriend, getFoe, getSelectedSetup],
+  (mode, friend, foe, selectedSetup) => adjustSetup(mode, friend, foe, selectedSetup)
 )
 
 const getAvailableCards = createSelector(
@@ -28,6 +34,8 @@ const getAvailableCards = createSelector(
 
 export const selectors = {
   getMode,
+  getFriend,
+  getFoe,
   getSelectedPlayerCount,
   getSelectedSetup,
   getConfiguration,

--- a/src/Redux/Store/TurnOrder/Configuration/types.ts
+++ b/src/Redux/Store/TurnOrder/Configuration/types.ts
@@ -6,12 +6,16 @@ import { actions } from './actions'
 
 export type State = Readonly<{
   Mode: types.Mode
+  Friend: boolean
+  Foe: boolean
   SelectedPlayerCount: types.ITurnOrderPlayerCount
   SelectedSetup: types.ITurnOrderSetup
 }>
 
 export enum ActionTypes {
   SET_MODE = 'TurnOrder/Configuration/SET_MODE',
+  SET_FRIEND = 'TurnOrder/Configuration/SET_FRIEND',
+  SET_FOE = 'TurnOrder/Configuration/SET_FOE',
   SELECT_PLAYER_COUNT = 'TurnOrder/Configuration/SELECT_PLAYER_COUNT',
   SELECT_SETUP = 'TurnOrder/Configuration/SELECT_SETUP',
   SET_TO_DB = 'TurnOrder/Configuration/SET_TO_DB',
@@ -28,6 +32,22 @@ export type ModeStateSlice = {
   TurnOrder: {
     Configuration: {
       Mode: types.Mode
+    }
+  }
+}
+
+export type FriendStateSlice = {
+  TurnOrder: {
+    Configuration: {
+      Friend: boolean
+    }
+  }
+}
+
+export type FoeStateSlice = {
+  TurnOrder: {
+    Configuration: {
+      Foe: boolean
     }
   }
 }

--- a/src/aer-data/src/turnOrderSetups.ts
+++ b/src/aer-data/src/turnOrderSetups.ts
@@ -58,6 +58,18 @@ export const TURNORDERCARDS: { [key: string]: ITurnOrderCard } = {
     name: 'Bone',
     type: 'bone',
   },
+
+  friend: {
+    id: 'friend',
+    name: 'Friend',
+    type: 'friend',
+  },
+  
+  foe: {
+    id: 'foe',
+    name: 'Foe',
+    type: 'foe',
+  },
 }
 
 export const TURNORDERSETUPS: ITurnOrderSetups = {

--- a/src/aer-types/types/turnOrder.ts
+++ b/src/aer-types/types/turnOrder.ts
@@ -14,6 +14,8 @@ export type Player =
   | 'Thief Of Dreams Delirium'
   | 'Myth'
   | 'Bone'
+  | 'Friend'
+  | 'Foe'
 
 export type TurnOrderCardType =
   | 'player1'
@@ -30,6 +32,8 @@ export type TurnOrderCardType =
   | 'thief-of-dreams'
   | 'myth'
   | 'bone'
+  | 'friend'
+  | 'foe'
 
 export interface ITurnOrderCard {
   id: string

--- a/src/components/pages/TurnOrder/ModeSelection.tsx
+++ b/src/components/pages/TurnOrder/ModeSelection.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 
 import CardContent from '@material-ui/core/CardContent'
+import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import FormLabel from '@material-ui/core/FormLabel'
 import Radio from '@material-ui/core/Radio'
@@ -24,15 +25,19 @@ const renderModeOptions = () =>
 
 const mapStateToProps = (state: RootState) => ({
   mode: selectors.TurnOrder.Configuration.getMode(state),
+  friend: selectors.TurnOrder.Configuration.getFriend(state),
+  foe: selectors.TurnOrder.Configuration.getFoe(state),
 })
 
 const mapDispatchToProps = {
   setMode: actions.TurnOrder.Configuration.setMode,
+  setFriend: actions.TurnOrder.Configuration.setFriend,
+  setFoe: actions.TurnOrder.Configuration.setFoe,
 }
 
 type Props = ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps & {}
 
-const ModeSelection = ({ mode, setMode }: Props) => (
+const ModeSelection = ({ mode, setMode, friend, setFriend, foe, setFoe }: Props) => (
   <Card>
     <CardContent>
       <FormLabel>Mode</FormLabel>
@@ -46,6 +51,26 @@ const ModeSelection = ({ mode, setMode }: Props) => (
       >
         {renderModeOptions()}
       </RadioGroup>
+      <FormControlLabel
+        control={
+          <Checkbox
+            id="friend"
+            checked={friend}
+            onChange={() => setFriend(!friend)}
+          />
+        }
+        label="Use Friend"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            id="foe"
+            checked={foe}
+            onChange={() => setFoe(!foe)}
+          />
+        }
+        label="Use Foe"
+      />
     </CardContent>
   </Card>
 )

--- a/src/mainTheme.ts
+++ b/src/mainTheme.ts
@@ -133,6 +133,14 @@ export const mainTheme = {
         normal: '#5B5B5B',
         light: '#AEAEAE',
       },
+      friend: {
+        normal: '#006400',
+        light: '#88AA88',
+      },
+      foe: {
+        normal: '#444',
+        light: '#aaa',
+      },
     },
     cards: {
       ...treasureColors,


### PR DESCRIPTION
A checkbox for each so you can have one or the other if desired.

Part of #522 