### PR TITLE
[Fix] Making Resonant Pearl exist

### DIFF
--- a/src/Redux/Store/Settings/Expansions/Cards/selected/__test__/__snapshots__/reducer.test.ts.snap
+++ b/src/Redux/Store/Settings/Expansions/Cards/selected/__test__/__snapshots__/reducer.test.ts.snap
@@ -168,7 +168,7 @@ Array [
   "Glowstone",
   "Encased Fossil",
   "FoolsGold",
-  "ResonantPearl",
+  "HarbingerDescent",
   "SplinteredGarnet",
   "SeersWrath",
   "TetheredSmite",

--- a/src/aer-data/src/ENG/pastAndFuture/cards.ts
+++ b/src/aer-data/src/ENG/pastAndFuture/cards.ts
@@ -118,7 +118,7 @@ export const cards: ICard[] = [
     type: 'Spell',
     expansion: 'PAF',
     name: 'Harbinger Descent',
-    id: 'ResonantPearl',
+    id: 'HarbingerDescent',
     cost: 8,
     effect: `
       <p>


### PR DESCRIPTION
Harbinger Descent has Resonant Pearl's ID, which I think prevents Pearl from showing up in the app. I'm not sure how to fix the cypress tests though.