### PR TITLE
Fix cost Rebound Spike

### DIFF
--- a/src/aer-data/src/ENG/TDPromos/cards.ts
+++ b/src/aer-data/src/ENG/TDPromos/cards.ts
@@ -23,7 +23,7 @@ export const cards: ICard[] = [
     expansion: 'TDPromo',
     name: 'Rebound Spike',
     id: 'ReboundSpike',
-    cost: 6,
+    cost: 5,
     effect: `
       <p>
       Set aside two gems or relics played


### PR DESCRIPTION
Rebound Spike has a Aether Value of 5.
See also: https://antifandom.com/aeonsend/wiki/Rebound_Spike
