### PR TITLE
Add info from fight five randomizers to existing nemeses

### DIFF
--- a/src/aer-data/src/ENG/aeonsEnd/nemeses.ts
+++ b/src/aer-data/src/ENG/aeonsEnd/nemeses.ts
@@ -9,6 +9,12 @@ export const nemeses: Nemesis[] = [
     difficulty: 3,
     expeditionRating: 1,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>The nemesis starts with 15 additional life.</p>
+    <p>Place Endless Throng on top of the nemesis deck instead of shuffling it into Tier 1.</p>
+    <p>Play using Increased Difficulty.</p>
+    `,
   },
   {
     expansion: 'AE',
@@ -18,6 +24,11 @@ export const nemeses: Nemesis[] = [
     difficulty: 5,
     expeditionRating: 2,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>The nemesis starts with 10 additional life.</p>
+    <p>Play using Increased Difficulty.</p>
+    `,
   },
   {
     expansion: 'AE',

--- a/src/aer-data/src/ENG/intoTheWild/nemeses.ts
+++ b/src/aer-data/src/ENG/intoTheWild/nemeses.ts
@@ -9,5 +9,10 @@ export const nemeses: Nemesis[] = [
     difficulty: 7,
     expeditionRating: 4,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>Play using Increased Difficulty.</p>
+    <p>SETUP: Two different players each suffer 2 damage.</p>
+    `,
   },
 ]

--- a/src/aer-data/src/ENG/legacy/nemeses.ts
+++ b/src/aer-data/src/ENG/legacy/nemeses.ts
@@ -18,6 +18,10 @@ export const nemeses: Nemesis[] = [
     difficulty: 6,
     expeditionRating: 4,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>Play using Increased Difficulty.</p>
+    `,
   },
   {
     expansion: 'Legacy',
@@ -62,5 +66,9 @@ export const nemeses: Nemesis[] = [
           During setup, include three less upgraded basic nemesis cards in each tier.
         </p>
       `,
+    fightFiveAdditionalInfo: `
+    <p>SETUP: After the spell deck is set up, destroy the top three cards of the spell deck. 
+       Then, the nemesis Concentrates three times.</p>
+    `
   },
 ]

--- a/src/aer-data/src/ENG/legacyOfGravehold/nemeses.ts
+++ b/src/aer-data/src/ENG/legacyOfGravehold/nemeses.ts
@@ -41,6 +41,10 @@ export const nemeses: Nemesis[] = [
     difficulty: 8,
     expeditionRating: 4,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>Play using Increased Difficulty.</p>
+    `,
   },
   {
     expansion: 'LOG',
@@ -55,6 +59,12 @@ export const nemeses: Nemesis[] = [
         Mist Revealed cards when constructing the nemesis deck.
       </p>
     `,
+    fightFiveAdditionalInfo: `
+    <p>When playing outside of the legacy campaign, use three random tier 3
+        Mist Revealed cards when constructing the nemesis deck.</p>
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>Play using Increased Difficulty.</p>
+    `
   },
   {
     expansion: 'LOG',

--- a/src/aer-data/src/ENG/origins/nemeses.ts
+++ b/src/aer-data/src/ENG/origins/nemeses.ts
@@ -9,5 +9,9 @@ export const nemeses: Nemesis[] = [
     difficulty: 5,
     expeditionRating: 3,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>SETUP: Put Atrophy into play from the Entropy deck.</p>
+    `,
   },
 ]

--- a/src/aer-data/src/ENG/outcasts/nemeses.ts
+++ b/src/aer-data/src/ENG/outcasts/nemeses.ts
@@ -36,5 +36,9 @@ export const nemeses: Nemesis[] = [
     difficulty: 8,
     expeditionRating: 4,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>SETUP: Two different players each suffer 2 damage.</p>
+    `,
   },
 ]

--- a/src/aer-data/src/ENG/pastAndFuture/nemeses.ts
+++ b/src/aer-data/src/ENG/pastAndFuture/nemeses.ts
@@ -54,5 +54,9 @@ export const nemeses: Nemesis[] = [
     difficulty: 8,
     expeditionRating: 4,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>Play using Increased Difficulty.</p>
+    `,
   },
 ]

--- a/src/aer-data/src/ENG/returnToGravehold/nemeses.ts
+++ b/src/aer-data/src/ENG/returnToGravehold/nemeses.ts
@@ -18,5 +18,9 @@ export const nemeses: Nemesis[] = [
     difficulty: 5,
     expeditionRating: 2,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>Play using Increased Difficulty.</p>
+    `,
   },
 ]

--- a/src/aer-data/src/ENG/theCaverns/nemeses.ts
+++ b/src/aer-data/src/ENG/theCaverns/nemeses.ts
@@ -9,5 +9,10 @@ export const nemeses: Nemesis[] = [
     difficulty: 8,
     expeditionRating: 4,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>SETUP: You must include the most expensive card in your Barracks in your supply.
+       Two different players each suffer 2 damage.</p>
+    `,
   },
 ]

--- a/src/aer-data/src/ENG/theDescent/nemeses.ts
+++ b/src/aer-data/src/ENG/theDescent/nemeses.ts
@@ -36,5 +36,9 @@ export const nemeses: Nemesis[] = [
     difficulty: 8,
     expeditionRating: 4,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>Play using Increased Difficulty.</p>
+    <p>SETUP: Two different players each suffer 3 damage.</p>
+    `,
   },
 ]

--- a/src/aer-data/src/ENG/theNameless/nemeses.ts
+++ b/src/aer-data/src/ENG/theNameless/nemeses.ts
@@ -9,6 +9,11 @@ export const nemeses: Nemesis[] = [
     difficulty: 4,
     expeditionRating: 2,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.
+       The unleash from this card resolves after checking to see if the Tainted Track advances.</p>
+    <p>SETUP: Gravehold suffers 5 damage. Two different players each suffer 2 damage.</p>
+    `,
   },
   {
     expansion: 'Nameless',

--- a/src/aer-data/src/ENG/theNewAge/nemeses.ts
+++ b/src/aer-data/src/ENG/theNewAge/nemeses.ts
@@ -18,6 +18,14 @@ export const nemeses: Nemesis[] = [
     difficulty: 4,
     expeditionRating: 2,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>The nemesis starts with 15 additional life.</p>
+    <p>SETUP: Gravehold suffers 4 damage.
+       Two different players each suffer 2 damage.
+       Arachnos gains four nemesis tokens.
+       Unleash twice.</p>
+    `,
   },
   {
     expansion: 'NA',

--- a/src/aer-data/src/ENG/theVoid/nemeses.ts
+++ b/src/aer-data/src/ENG/theVoid/nemeses.ts
@@ -9,6 +9,11 @@ export const nemeses: Nemesis[] = [
     difficulty: 4,
     expeditionRating: 1,
     additionalInfo: '',
+    fightFiveAdditionalInfo: `
+    <p>During setup, swap one of the nemesis turn order cards for the Unleash turn order card.</p>
+    <p>The nemesis starts with 20 additional life.</p>
+    <p>SETUP: Unleash.</p>
+    `,
   },
   {
     expansion: 'TV',

--- a/src/aer-data/src/ENG/warEternal/nemeses.ts
+++ b/src/aer-data/src/ENG/warEternal/nemeses.ts
@@ -14,6 +14,10 @@ export const nemeses: Nemesis[] = [
           instead of four nemesis tokens.
         </p>
       `,
+    fightFiveAdditionalInfo: `
+    <p>The nemesis starts with 20 additional life.</p>
+    <p>SETUP: Gate Witch starts with 4 nemesis tokens instead of 1.</p>
+    `,
   },
   {
     expansion: 'WE',

--- a/src/aer-types/types/data.ts
+++ b/src/aer-types/types/data.ts
@@ -104,6 +104,7 @@ export type Nemesis = ICreature & {
   additionalInfo: string
   difficulty: number
   expeditionRating: ExpeditionRating
+  fightFiveAdditionalInfo?: string
 }
 
 export type Mage = ICreature & {


### PR DESCRIPTION
When picking a nemesis for fight 5, we can filter on the presence of this field instead of the value of expedition rating. This doesn't support a nemesis having randomizer cards for multiple non-5 rounds, or a nemesis that can only be fought in fight 5, neither of which currently exist, but it minimizes the data changes for existing nemeses.

Part of #553.