### PR TITLE
Fight Five

### DIFF
--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/createBattle/getStillAvailableNemesisIds.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/createBattle/getStillAvailableNemesisIds.ts
@@ -1,15 +1,14 @@
 import * as types from 'aer-types/types'
 
 export const getStillAvailableNemesisIds = (
-  availableNemeses: Array<{
-    id: string
-    expeditionRating: types.ExpeditionRating
-  }>,
+  availableNemeses: Array<types.Nemesis>,
   previousNemeses: string[],
   nemesisTier: types.NemesisTier
 ) => {
   return availableNemeses
-    .filter((nemesis) => nemesis.expeditionRating === nemesisTier)
+    .filter(nemesisTier === 5 ?
+      (nemesis) => nemesis.fightFiveAdditionalInfo !== undefined :
+      (nemesis) => nemesis.expeditionRating === nemesisTier)
     .map((nemesis) => nemesis.id)
     .filter((nemesisId) => !previousNemeses.includes(nemesisId))
 }

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/createBattle/getUpgradedBasicNemesisIdsByBattleTier.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/createBattle/getUpgradedBasicNemesisIdsByBattleTier.ts
@@ -21,12 +21,13 @@ export const getUpgradedBasicNemesisIdsByBattleTier = ({
   availableTier1Ids: string[]
   availableTier2Ids: string[]
   availableTier3Ids: string[]
-  battleTier: 1 | 2 | 3 | 4
+  battleTier: types.NemesisTier
   getEntity: types.SeededEntityGetter
   seed: types.Seed
 }): { result: string[]; seed: types.Seed } => {
   switch (battleTier) {
-    case 1: {
+    case 1:
+    case 5: {
       return { result: [], seed } // No upgraded cards are added on tier 1
     }
 

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/createBattle/rollNewUpgradedNemesisCards.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/createBattle/rollNewUpgradedNemesisCards.ts
@@ -8,7 +8,7 @@ export const rollNewUpgradedNemesisCards = (
     tier: types.NemesisCardTier
   }[],
   previousUpgradedBasicNemesisCards: string[],
-  nemesisTier: 1 | 2 | 3 | 4,
+  nemesisTier: types.NemesisTier,
   getEntity: types.SeededEntityGetter,
   seed: types.Seed
 ) => {

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollLossRewards/index.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollLossRewards/index.ts
@@ -32,6 +32,7 @@ export const handleRewardType = ({
   treasure1Ids,
   treasure2Ids,
   treasure3Ids,
+  treasure4Ids,
 }: {
   rewardType: RewardType
   battle: types.Battle
@@ -44,6 +45,7 @@ export const handleRewardType = ({
   treasure1Ids: string[]
   treasure2Ids: string[]
   treasure3Ids: string[]
+  treasure4Ids: string[]
 }) => {
   switch (rewardType) {
     case 'mage': {
@@ -72,6 +74,10 @@ export const handleRewardType = ({
 
     case 'treasure3': {
       return handleTreasure(battle, treasure3Ids, seed)
+    }
+
+    case 'treasure4': {
+      return handleTreasure(battle, treasure4Ids, seed)
     }
 
     case 'banner': {
@@ -129,6 +135,10 @@ const rollLossRewards = (
     treasureLevel: 3,
     expeditionId,
   })
+  const treasure4Ids = selectors.getStillAvailableTreasureIdsByLevel(state, {
+    treasureLevel: 4,
+    expeditionId,
+  })
   const bannerIds = selectors.getStillAvailableBannerIds(state, { expeditionId })
 
   const mageIds = expedition.uniqueMageNames
@@ -146,6 +156,7 @@ const rollLossRewards = (
     treasure1Ids,
     treasure2Ids,
     treasure3Ids,
+    treasure4Ids,
     bannerIds,
   })
 }

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/index.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/index.ts
@@ -6,7 +6,7 @@ import * as types from 'aer-types/types'
 import { rollTreasureIdsByLevel } from 'Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/rollTreasureIdsByLevel'
 import { rollSupplyRewards } from 'Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/rollSupplyRewards'
 
-import { handleCustomRewards } from '../helpers'
+import { handleCustomRewards, rollNewEntity } from '../helpers'
 
 export const getTreasureAmount = (treasureLevel?: types.TreasureLevel) => {
   return treasureLevel === 2 ? 3 : 5
@@ -29,16 +29,16 @@ export const rollWinRewards = (
     seed: expedition.seed.seed,
     state: expedition.seed.supplyState,
   }
+  const treasureLevel = battle.config.treasure.level
 
   const stillAvailableTreasureIds =
-    battle.config.treasure.hasTreasure && battle.config.treasure.level
+    battle.config.treasure.hasTreasure && treasureLevel
       ? selectors.getStillAvailableTreasureIdsByLevel(state, {
-          treasureLevel: battle.config.treasure.level,
+          treasureLevel,
           expeditionId,
         })
       : []
 
-  const treasureLevel = battle.config.treasure.level
   const amountOfTreasures = getTreasureAmount(treasureLevel)
 
   const newTreasuresResult = rollTreasureIdsByLevel(
@@ -47,8 +47,32 @@ export const rollWinRewards = (
     getRandomEntity,
     seed
   )
+  let nextSeed = newTreasuresResult.seed
 
   const newTreasures = newTreasuresResult.result
+  if (treasureLevel === 4) {
+    // You also get 2 level 1s, 1 level 2, and 2 level 3s.
+    const level1s = rollTreasureIdsByLevel(
+      selectors.getStillAvailableTreasureIdsByLevel(state, {treasureLevel: 1, expeditionId}),
+      2,
+      getRandomEntity,
+      nextSeed
+    )
+    const level2s = rollTreasureIdsByLevel(
+      selectors.getStillAvailableTreasureIdsByLevel(state, {treasureLevel: 2, expeditionId}),
+      1,
+      getRandomEntity,
+      level1s.seed
+    )
+    const level3s = rollTreasureIdsByLevel(
+      selectors.getStillAvailableTreasureIdsByLevel(state, {treasureLevel: 3, expeditionId}),
+      2,
+      getRandomEntity,
+      level2s.seed
+    )
+    nextSeed = level3s.seed
+    newTreasures.push(...level1s.result, ...level2s.result, ...level3s.result)
+  }
 
   const gemIds = selectors.getStillAvailableGemIds(state, {
     expeditionId,
@@ -64,21 +88,42 @@ export const rollWinRewards = (
     gemIds,
     relicIds,
     spellIds,
-    newTreasuresResult.seed
+    nextSeed
   )
   const supplyRewards = supplyRewardsResult.result
+  nextSeed = supplyRewardsResult.seed
+  const mages : string[] = []
+  if (treasureLevel === 4) {
+    // You get another gem, relic, spell, and mage with level 4 treasures.
+    // Can't use getStillAvailableSpellIds again because we haven't updated the expedition state yet.
+    const notJustGiven = (x: string) => !supplyRewards.includes(x)
+    const moreSupplyRewards = rollSupplyRewards(
+      gemIds.filter(notJustGiven),
+      relicIds.filter(notJustGiven),
+      spellIds.filter(notJustGiven),
+      nextSeed
+    )
+    supplyRewards.push(...moreSupplyRewards.result)
+
+    const mageIds = expedition.uniqueMageNames
+      ? selectors.getStillAvailableMageWithUniqueNameIds(state, { expeditionId })
+      : selectors.getStillAvailableMageIds(state, { expeditionId })
+    const mageResult = rollNewEntity(mageIds, getRandomEntity, moreSupplyRewards.seed)
+    mages.push(mageResult.result)
+    nextSeed = mageResult.seed
+  }
 
   const updatedBattle: types.Battle = {
     ...battle,
     rewards: {
       treasure: newTreasures,
       supplyIds: supplyRewards,
-      mages: [], // we explicitely overwrite the mage reward from earlier losses
+      mages
     },
   }
   return {
     battle: updatedBattle,
-    seed: supplyRewardsResult.seed,
+    seed: nextSeed,
   }
 }
 

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/rollSupplyRewards.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/rollSupplyRewards.ts
@@ -9,7 +9,7 @@ export const rollSupplyRewards = (
   relicIds: string[],
   spellIds: string[],
   seed: types.Seed,
-  rollNewEntityFn: Function = rollNewEntity
+  rollNewEntityFn: typeof rollNewEntity = rollNewEntity
 ) => {
   // We pack the values into arrays to make it possible to get empty values
   // which are not null below

--- a/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/rollTreasureIdsByLevel.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/sideEffects/rollWinRewards/rollTreasureIdsByLevel.ts
@@ -20,7 +20,7 @@ export const rollTreasureIdsByLevel = (
           getEntity,
           seed
         )
-      : { result: [], seed }
+      : { availableEntities: [], result: [], seed }
 
   return newTreasures
 }

--- a/src/Redux/Store/Expeditions/Expeditions/types.ts
+++ b/src/Redux/Store/Expeditions/Expeditions/types.ts
@@ -69,6 +69,7 @@ export type RewardType =
   | 'treasure1'
   | 'treasure2'
   | 'treasure3'
+  | 'treasure4'
   | 'banner'
 
 export type BattleRewardsResult = types.Battle & {
@@ -85,6 +86,7 @@ export type LossConfig = {
   treasure1Ids: string[]
   treasure2Ids: string[]
   treasure3Ids: string[]
+  treasure4Ids: string[]
   bannerIds: string[]
 }
 

--- a/src/aer-types/types/expeditions.ts
+++ b/src/aer-types/types/expeditions.ts
@@ -41,6 +41,37 @@ export const variants: { [id: string]: Variant } = {
       },
     ],
   },
+  FIGHT_FIVE: {
+    id: 'FIGHT_FIVE',
+    name: 'Fight Five',
+    configList: [
+      {
+        tier: 1,
+        newUBNCards: { type: 'regular', addRandom: false },
+        treasure: { level: 1, hasTreasure: true },
+      },
+      {
+        tier: 2,
+        newUBNCards: { type: 'regular', addRandom: true },
+        treasure: { level: 2, hasTreasure: true },
+      },
+      {
+        tier: 3,
+        newUBNCards: { type: 'regular', addRandom: true },
+        treasure: { level: 3, hasTreasure: true },
+      },
+      {
+        tier: 4,
+        newUBNCards: { type: 'regular', addRandom: true },
+        treasure: { level: 4, hasTreasure: true },
+      },
+      {
+        tier: 5,
+        newUBNCards: { type: 'regular', addRandom: true },
+        treasure: { hasTreasure: false },
+      },
+    ],
+  },
   SHORT: {
     id: 'SHORT',
     name: 'Short',
@@ -189,7 +220,7 @@ export type Barracks = {
 
 export type OnLoss = 'skip'
 
-export type NemesisTier = 1 | 2 | 3 | 4
+export type NemesisTier = 1 | 2 | 3 | 4 | 5
 
 ///////////////////
 // Configuration //

--- a/src/components/molecules/NemesisInformation/index.tsx
+++ b/src/components/molecules/NemesisInformation/index.tsx
@@ -27,6 +27,7 @@ const mapDispatchToProps = {}
 
 type OwnProps = {
   nemesis?: Nemesis
+  fightFive?: boolean
   theme: any
 }
 
@@ -34,10 +35,11 @@ type Props = ReturnType<typeof mapStateToProps> &
   typeof mapDispatchToProps &
   OwnProps
 
-const NemesisInformation = ({ nemesis, expansion, theme }: Props) => {
+const NemesisInformation = ({ nemesis, fightFive = false, expansion, theme }: Props) => {
   if (!expansion || !nemesis) {
     return null
   }
+  const additionalInfo = fightFive ? nemesis.fightFiveAdditionalInfo : nemesis.additionalInfo
 
   return (
     <React.Fragment>
@@ -47,9 +49,9 @@ const NemesisInformation = ({ nemesis, expansion, theme }: Props) => {
       <InfoItem label="Difficulty" info={nemesis.difficulty.toString()} />
       <InfoItem
         label="Expedition tier"
-        info={nemesis.expeditionRating.toString()}
+        info={fightFive ? "5" : nemesis.expeditionRating.toString()}
       />
-      {nemesis.additionalInfo ? (
+      {additionalInfo ? (
         <React.Fragment>
           <SectionHeadline
             themeColor={theme.colors.turnOrderCards['nemesis'].normal}
@@ -58,7 +60,7 @@ const NemesisInformation = ({ nemesis, expansion, theme }: Props) => {
           </SectionHeadline>
           <AdditionalInfo
             dangerouslySetInnerHTML={{
-              __html: nemesis.additionalInfo,
+              __html: additionalInfo,
             }}
           />
         </React.Fragment>

--- a/src/components/pages/Expeditions/Expedition/Branch/Battle/BattleLost/LossRewardTypeSelection/index.tsx
+++ b/src/components/pages/Expeditions/Expedition/Branch/Battle/BattleLost/LossRewardTypeSelection/index.tsx
@@ -13,10 +13,11 @@ import SectionHeadline from 'components/atoms/SectionHeadline'
 import RewardSelect from './RewardSelect'
 import ConfirmButton from './ConfirmButton'
 
-const getTreasureOptionsByTier = (tier: 1 | 2 | 3 | 4) => [
-  ...([2, 3, 4].includes(tier) ? [{ level: 1 }] : []),
-  ...([3, 4].includes(tier) ? [{ level: 2 }] : []),
-  ...([4].includes(tier) ? [{ level: 3 }] : []),
+const getTreasureOptionsByTier = (tier: 1 | 2 | 3 | 4 | 5) => [
+  ...([2, 3, 4, 5].includes(tier) ? [{ level: 1 }] : []),
+  ...([3, 4, 5].includes(tier) ? [{ level: 2 }] : []),
+  ...([4, 5].includes(tier) ? [{ level: 3 }] : []),
+  ...([5].includes(tier) ? [{ level: 4 }] : []),
 ]
 
 type OwnProps = {

--- a/src/components/pages/Expeditions/Expedition/Branch/Battle/BeforeBattle/BattleOverview.tsx
+++ b/src/components/pages/Expeditions/Expedition/Branch/Battle/BeforeBattle/BattleOverview.tsx
@@ -18,6 +18,7 @@ type Props = {
   specialRules?: string
   onLoss?: string
   upgradedBasicNemsisCards: types.UpgradedBasicNemesisCard[]
+  tier: types.NemesisTier
 }
 
 const BattleOverview = ({
@@ -28,6 +29,7 @@ const BattleOverview = ({
   upgradedBasicNemsisCards,
   specialRules,
   onLoss,
+  tier,
 }: Props) => {
   return (
     <>
@@ -35,7 +37,7 @@ const BattleOverview = ({
       <SectionHeadline data-test={`${nemesis?.name}`}>
         {nemesis ? nemesis.name : 'Nemesis'}
       </SectionHeadline>
-      <NemesisInformation nemesis={nemesis} />
+      <NemesisInformation nemesis={nemesis} fightFive={tier === 5} />
       {friend && <>
         <SectionHeadline data-test="friend">Friend: {friend.name}</SectionHeadline>
         <FriendInformation friend={friend} simple={true} />

--- a/src/components/pages/Expeditions/Expedition/Branch/Battle/BeforeBattle/index.tsx
+++ b/src/components/pages/Expeditions/Expedition/Branch/Battle/BeforeBattle/index.tsx
@@ -62,6 +62,7 @@ const BeforeBattle = ({
           nemesis={nemesis}
           foe={foe}
           friend={friend}
+          tier={battle.config.tier}
           upgradedBasicNemsisCards={upgradedBasicNemsisCards}
         />
       </ModalBodyWrapper>

--- a/src/mainTheme.ts
+++ b/src/mainTheme.ts
@@ -56,12 +56,16 @@ const treasureColors = {
     light: '#ffddb2',
   },
   treasure2: {
-    normal: '#aaa9ad',
-    light: '#ece8f5',
+    normal: '#5a59ad',
+    light: '#bcb8f5',
   },
   treasure3: {
     normal: '#d4af37',
     light: '#fbecbb',
+  },
+  treasure4: {
+    normal: '#aaa9ad',
+    light: '#ece8f5',
   },
 }
 


### PR DESCRIPTION
Adds fight five as an expedition config, with the special cases necessary to use nemeses of any level that have a `fightFiveAdditionalInfo` for the nemesis, and the extra rewards you get before that fight according to the rulebook.

Fixes #553 